### PR TITLE
Rancher registry standalone package

### DIFF
--- a/packages/aws/rancher-registry.yaml
+++ b/packages/aws/rancher-registry.yaml
@@ -1,0 +1,27 @@
+manifest:
+  name: rancher-registry
+  description: rancher-registry
+  variables:
+    registry_auth:
+      default: enabled
+templates:
+  - aws/cluster_nodes
+  - aws/registry_nodes
+  - registry-standalone
+  - rke2
+  - rancher
+variables:
+  cni:
+    - calico
+  kubernetes_version:
+    - v1.23.10+rke2r1
+  registry_auth:
+    - global
+    - enabled
+    - disabled
+  docker_compose_version:
+    - 2.15.1
+  rancher_version:
+    - 2.7.0
+  cert_manager_version:
+    - 1.8.0

--- a/packages/aws/rancher.yaml
+++ b/packages/aws/rancher.yaml
@@ -21,3 +21,5 @@ variables:
     - 2.6.2
     - 2.6.1
     - 2.6.0
+  cert_manager_version:
+    - 1.8.0

--- a/packages/aws/registry.yaml
+++ b/packages/aws/registry.yaml
@@ -1,0 +1,21 @@
+manifest:
+  name: registry
+  description: registry
+  variables:
+    registry_auth:
+      default: enabled
+templates:
+  - aws/registry_nodes
+  - registry-standalone
+variables:
+  registry_auth:
+    - global
+    - enabled
+    - disabled
+  docker_compose_version:
+    - 2.15.1
+  rancher_version:
+    - 2.7.0
+  cert_manager_version:
+    - 1.8.0
+  

--- a/templates/aws/registry_nodes/manifest.yaml
+++ b/templates/aws/registry_nodes/manifest.yaml
@@ -1,0 +1,59 @@
+name: aws-registry-nodes
+description: |
+  Creates ec2 instances in AWS with a Route53 record to their public ip for registries.
+variables:
+  aws_access_key:
+    sensitive: true
+    type: string
+    optional: false
+    description: "aws API access key"
+  aws_secret_key:
+    sensitive: true
+    type: string
+    optional: false
+    description: "aws API secret key"
+  aws_region:
+    type: string
+    optional: false
+    description: "The region the ec2 instance would be created"
+  aws_ami:
+    type: string
+    optional: false
+    description: "The image of the ec2 instance"
+  aws_route53_zone:
+    type: string
+    optional: false
+    description: "The route 53 hosted zone"
+  aws_ssh_user:
+    type: string
+    optional: false
+    description: "The user need to initally ssh into an instance i.e ubuntu"
+  aws_security_group:
+    type: string
+    optional: false
+    description: "The security group needed for an ec2 instance"
+  aws_vpc:
+    type: string
+    optional: false
+    description: "The vpc of where the target group is located"
+  aws_subnet:
+    type: string
+    optional: false
+    description: "The subnet where the ec2 instance and the load balancer is created"
+  instance_type:
+    type: string
+    optional: false
+    description: "What size ec2 instance to use for the nodes."
+  registry_fqdn:
+    type: string
+    readOnly: true
+    description: "Public DNS A record that directs to the registry node."
+  registry_ip:
+    type: string
+    readOnly: true
+    description: "Public IP address of the registry node"
+commands:
+  - module: pools
+  - command: "echo \"$CORRAL_corral_user_public_key\" >> /$(whoami)/.ssh/authorized_keys"
+    node_pools:
+      - registry

--- a/templates/aws/registry_nodes/terraform/pools/cloud-init/setup-docker-service.yaml
+++ b/templates/aws/registry_nodes/terraform/pools/cloud-init/setup-docker-service.yaml
@@ -1,0 +1,21 @@
+#cloud-config
+write_files:
+  - path: /etc/systemd/system/docker-registry.service
+    owner: root:root
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=Docker registry service with docker compose
+      PartOf=docker.service
+      After=docker.service
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=true
+      WorkingDirectory=/opt/basic-registry/
+      ExecStart=/usr/bin/docker-compose up -d --remove-orphans
+      ExecStop=/usr/bin/docker-compose down
+      ExecStartPost=/usr/bin/timeout 30 sh -c 'while ! ss -H -t -l -n sport = :443 | grep -q "^LISTEN.*:443"; do sleep 1; done'
+
+      [Install]
+      WantedBy=multi-user.target  

--- a/templates/aws/registry_nodes/terraform/pools/corral.tf
+++ b/templates/aws/registry_nodes/terraform/pools/corral.tf
@@ -1,0 +1,15 @@
+variable "corral_name" {} // name of the corral being created
+variable "corral_user_id" {} // how the user is identified (usually github username)
+variable "corral_public_key" {} // The corrals public key.  This should be installed on every node.
+variable "corral_private_key" {} // The corrals private key.  This should be installed on every node to be able to have root access, as aws does not allow this by default.
+
+variable "aws_access_key" {}
+variable "aws_secret_key" {}
+variable "aws_region" {}
+variable "aws_ami" {}
+variable "aws_route53_zone" {}
+variable "aws_ssh_user" {}
+variable "aws_security_group" {}
+variable "aws_vpc" {}
+variable "aws_subnet" {}
+variable "instance_type" {}

--- a/templates/aws/registry_nodes/terraform/pools/main.tf
+++ b/templates/aws/registry_nodes/terraform/pools/main.tf
@@ -1,0 +1,83 @@
+terraform {
+  required_version = ">= 0.13.1"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "random" {}
+provider "aws" {
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+  region     = var.aws_region
+}
+
+resource "random_id" "cluster_id" {
+  byte_length       = 6
+}
+
+resource "aws_key_pair" "corral_key" {
+  key_name       = "corral-${var.corral_user_id}-${random_id.cluster_id.hex}"
+  public_key = var.corral_public_key
+}
+
+data "cloudinit_config" "docker_service_config" {
+  gzip          = true
+  base64_encode = true
+  part {
+    content_type = "text/cloud-config"
+    content = file("${path.module}/cloud-init/setup-docker-service.yaml")
+  }
+}
+
+resource "aws_instance" "registry" {
+  ami = var.aws_ami
+  instance_type     = var.instance_type
+  key_name = aws_key_pair.corral_key.key_name
+  vpc_security_group_ids = [var.aws_security_group]
+  subnet_id = var.aws_subnet
+  user_data = data.cloudinit_config.docker_service_config.rendered
+
+  ebs_block_device {
+    device_name           = "/dev/sda1"
+    volume_size           = "200"
+    volume_type           = "gp3"
+    encrypted             = true
+    delete_on_termination = true
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo su <<EOF",
+      "echo ${var.corral_public_key} ${self.key_name} > /root/.ssh/authorized_keys",
+      "EOF",
+    ]
+  }
+  connection {
+      type        = "ssh"
+      host        = self.public_ip
+      user        = var.aws_ssh_user
+      private_key = var.corral_private_key
+      timeout     = "4m"
+   }
+
+  tags = {
+    Name  = "${var.corral_user_id}-${random_id.cluster_id.hex}-registry"
+  }
+}
+
+resource "aws_route53_record" "aws_route53" {
+  zone_id            = data.aws_route53_zone.selected.zone_id
+  name               = "${aws_instance.registry.tags.Name}"
+  type               = "A"
+  ttl                = "300"
+  records            = [aws_instance.registry.public_ip]
+}
+
+data "aws_route53_zone" "selected" {
+  name               = var.aws_route53_zone
+  private_zone       = false
+}

--- a/templates/aws/registry_nodes/terraform/pools/outputs.tf
+++ b/templates/aws/registry_nodes/terraform/pools/outputs.tf
@@ -1,0 +1,17 @@
+output "registry_fqdn" {
+  value = aws_route53_record.aws_route53.fqdn
+}
+
+output "registry_ip" {
+  value = aws_instance.registry.public_ip
+}
+
+output "corral_node_pools" {
+  value = {
+    registry = [for node in [aws_instance.registry] : {
+      name = node.tags.Name
+      user = "root"
+      address = node.public_ip
+    }]
+  }
+}

--- a/templates/rancher/manifest.yaml
+++ b/templates/rancher/manifest.yaml
@@ -16,6 +16,9 @@ variables:
     readOnly: true
     type: string
     description: "Host of newly created rancher instance."
+  cert_manager_version:
+    type: string
+    description: "The cert-manager version for HA rancher install"
 commands:
   - command: /opt/corral/rancher/preflight.sh
     node_pools:

--- a/templates/rancher/overlay/opt/corral/rancher/install-cert-manager.sh
+++ b/templates/rancher/overlay/opt/corral/rancher/install-cert-manager.sh
@@ -4,13 +4,32 @@ set -ex
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 
-helm upgrade \
-  --install \
-  --create-namespace \
-  -n cert-manager \
-  --set installCRDs=true \
-  --version v1.8.0 \
-  --wait \
-  cert-manager jetstack/cert-manager
+if [ -z "${CORRAL_registry_fqdn}" ]; then
+
+	helm upgrade \
+		--install \
+		--create-namespace \
+		-n cert-manager \
+		--set installCRDs=true \
+		--version v${CORRAL_cert_manager_version} \
+		--wait \
+		cert-manager jetstack/cert-manager
+
+else
+
+	helm fetch jetstack/cert-manager --version "v${CORRAL_cert_manager_version}"
+	tar xvzf "cert-manager-v${CORRAL_cert_manager_version}.tgz"
+	curl -L -o cert-manager/cert-manager-crd.yaml "https://github.com/cert-manager/cert-manager/releases/download/v${CORRAL_cert_manager_version}/cert-manager.crds.yaml"
+	kubectl create namespace cert-manager
+	kubectl apply -f cert-manager/cert-manager-crd.yaml
+
+	helm install cert-manager "./cert-manager-v${CORRAL_cert_manager_version}.tgz" \
+		--namespace cert-manager \
+		--set image.repository="${CORRAL_registry_fqdn}/quay.io/jetstack/cert-manager-controller" \
+		--set webhook.image.repository="${CORRAL_registry_fqdn}/quay.io/jetstack/cert-manager-webhook" \
+		--set cainjector.image.repository="${CORRAL_registry_fqdn}/quay.io/jetstack/cert-manager-cainjector" \
+		--set startupapicheck.image.repository="${CORRAL_registry_fqdn}/quay.io/jetstack/cert-manager-ctl"
+
+fi
 
 sleep 1m

--- a/templates/rancher/overlay/opt/corral/rancher/install-rancher.sh
+++ b/templates/rancher/overlay/opt/corral/rancher/install-rancher.sh
@@ -7,15 +7,16 @@ helm repo update
 CORRAL_rancher_host=${CORRAL_rancher_host:="${CORRAL_fqdn}"}
 CORRAL_rancher_version=${CORRAL_rancher_version:=$(helm search repo rancher-latest/rancher -o json | jq -r .[0].version)}
 
-helm upgrade \
-  --install \
-  --create-namespace \
-  --set hostname="$CORRAL_rancher_host" \
-  --version "$CORRAL_rancher_version" \
-  --devel \
-  --wait \
-  -n cattle-system \
-  rancher rancher-latest/rancher
+args=("--install" "--create-namespace")
+
+if [ -z "${CORRAL_registry_fqdn}" ]; then
+	args+=("--set hostname=${CORRAL_rancher_host}" "--version ${CORRAL_rancher_version}")
+else
+	args+=("--set hostname=${CORRAL_rancher_host}" "--set rancherImage=${CORRAL_registry_fqdn}/rancher/rancher" "--set systemDefaultRegistry=${CORRAL_registry_fqdn}" "--version ${CORRAL_rancher_version}")
+fi
+
+args+=("--devel" "--wait" "-n cattle-system" "rancher rancher-latest/rancher")
+eval "helm upgrade ${args[@]}"
 
 echo "corral_set rancher_host=$CORRAL_rancher_host"
 echo "corral_set rancher_url=https://$CORRAL_rancher_host"

--- a/templates/registry-standalone/manifest.yaml
+++ b/templates/registry-standalone/manifest.yaml
@@ -1,0 +1,46 @@
+name: registry
+description: |
+  A docker registry
+variables:
+  registry_fqdn:
+    type: string
+    readOnly: true
+    description: "The registry fqdn"
+  registry_ip:
+    type: string
+    readOnly: true
+    description: "The registry IP address"
+  registry_host:
+    type: string
+    readOnly: true
+    description: "host the configured registry can be accessed at"
+  registry_username:
+    type: string
+    readOnly: true
+    description: "username for registry authentication"
+  registry_password:
+    type: string
+    readOnly: true
+    description: "password for registry authentication"
+  registry_cert:
+    type: string
+    description: "domain certificate"
+  registry_key:
+    type: string
+    description: "domain certificate key"
+  registry_auth:
+    type: string
+    description: "Flag to build an auth enabled registry or no auth"
+  rancher_version:
+    type: string
+    description: "The rancher version to download the images for"
+  cert_manager_version:
+    type: string
+    description: "The cert-manager version for HA rancher install"
+  docker_compose_version:
+    type: string
+    description: "The docker compose version used for running the registry"
+commands:
+  - command: /opt/corral/registry/registry-install.sh
+    node_pools:
+      - registry

--- a/templates/registry-standalone/overlay/opt/basic-registry/docker-compose.yml
+++ b/templates/registry-standalone/overlay/opt/basic-registry/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "2"
+
+services:
+  web:
+    image: nginx
+    ports:
+      - 443:443
+
+    links:
+      - registry:registry
+    volumes:
+      - ./nginx_config:/etc/nginx/conf.d/
+
+  registry:
+    # v2.6 is needed to support Windows images in the registry, otherwise will get 500 Internal Server Error
+    image: registry:2.6
+    ports:
+    - 127.0.0.1:5000:5000

--- a/templates/registry-standalone/overlay/opt/basic-registry/nginx_config/nginx.conf
+++ b/templates/registry-standalone/overlay/opt/basic-registry/nginx_config/nginx.conf
@@ -1,0 +1,38 @@
+upstream docker-registry {
+  server registry:5000;
+}
+
+server {
+  listen 443 ssl;
+  server_name _;
+
+  # SSL
+  ssl_certificate /etc/nginx/conf.d/domain.crt;
+  ssl_certificate_key /etc/nginx/conf.d/domain.key;
+
+  # disable any limits to avoid HTTP 413 for large image uploads
+  client_max_body_size 0;
+
+  # required to avoid HTTP 411: see Issue #1486 (https://github.com/docker/docker/issues/1486)
+  chunked_transfer_encoding on;
+
+  location /v2/ {
+    # Do not allow connections from docker 1.5 and earlier
+    # docker pre-1.6.0 did not properly set the user agent on ping, catch "Go *" user agents
+    if ($http_user_agent ~ "^(docker\/1\.(3|4|5(?!\.[0-9]-dev))|Go ).*$" ) {
+      return 404;
+    }
+
+    # To add basic authentication to v2 use auth_basic setting plus add_header
+    auth_basic "registry.localhost";
+    auth_basic_user_file /etc/nginx/conf.d/registry.password;
+    add_header 'Docker-Distribution-Api-Version' 'registry/2.0' always;
+
+    proxy_pass                          http://docker-registry;
+    proxy_set_header  Host              $http_host;   # required for docker client's sake
+    proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
+    proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header  X-Forwarded-Proto $scheme;
+    proxy_read_timeout                  900;
+  }
+}

--- a/templates/registry-standalone/overlay/opt/corral/registry/registry-install.sh
+++ b/templates/registry-standalone/overlay/opt/corral/registry/registry-install.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -ex
+
+DOWNLOAD_URL="https://github.com/rancher/rancher/releases/download/"
+
+function corral_set() {
+    echo "corral_set $1=$2"
+}
+
+function corral_log() {
+    echo "corral_log $1"
+}
+
+corral_log "Build started for registry $CORRAL_registry_fqdn"
+echo "$CORRAL_corral_user_public_key" >> "$HOME"/.ssh/authorized_keys
+echo "$CORRAL_registry_cert" | base64 -d > /opt/basic-registry/nginx_config/domain.crt
+echo "$CORRAL_registry_key" | base64 -d > /opt/basic-registry/nginx_config/domain.key
+
+corral_log "Downloading Dependencies"
+
+curl -SL https://github.com/docker/compose/releases/download/v$CORRAL_docker_compose_version/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+
+if [ "enabled" = "$CORRAL_registry_auth" ]; then
+    corral_log "Building registry with auth"
+    
+    USERNAME="corral"
+    PASSWORD="$( echo $RANDOM | md5sum | head -c 12)"
+
+    corral_set registry_username "$USERNAME"
+    corral_set registry_password "$PASSWORD"
+
+    # This is used to avoid the dependency on apache-utils htpasswd
+    SALT=$(openssl rand -base64 3)
+    SHA1=$(echo -n "${PASSWORD}${SALT}" | openssl dgst -binary -sha1 | xxd -p | sed "s/$/$(echo -n ${SALT} | xxd -p)/" | xxd -r -p | base64)
+    echo "$USERNAME:{SSHA}$SHA1" > /opt/basic-registry/nginx_config/registry.password
+else
+    corral_log "Building no auth registry"
+
+    sed -i -e 's/auth_basic/#auth_basic/g' /opt/basic-registry/nginx_config/nginx.conf
+    sed -i -e 's/add_header/#add_header/g' /opt/basic-registry/nginx_config/nginx.conf
+fi
+
+corral_log "Enabling docker registry systemd service"
+
+systemctl enable docker-registry.service
+systemctl start docker-registry.service
+
+corral_log "Downloading Rancher registry scripts from release"
+
+wget -O rancher-images.txt "${DOWNLOAD_URL}v${CORRAL_rancher_version}"/rancher-images.txt
+wget -O rancher-save-images.sh "${DOWNLOAD_URL}v${CORRAL_rancher_version}"/rancher-save-images.sh
+wget -O rancher-load-images.sh "${DOWNLOAD_URL}v${CORRAL_rancher_version}"/rancher-load-images.sh
+sed -i 's/docker save/# docker save /g' rancher-save-images.sh
+sed -i 's/docker load/# docker load /g' rancher-load-images.sh
+chmod +x rancher-save-images.sh 
+chmod +x rancher-load-images.sh
+
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
+
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm fetch jetstack/cert-manager --version "v${CORRAL_cert_manager_version}"
+helm template ./cert-manager-"v${CORRAL_cert_manager_version}".tgz | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g >> ./rancher-images.txt
+sort -u rancher-images.txt -o rancher-images.txt
+
+corral_log "Saving images to host. Estimated time 1hr"
+
+bash rancher-save-images.sh --image-list rancher-images.txt
+
+if [ "enabled" = "$CORRAL_registry_auth" ]; then
+    corral_log "Login to the registry to load images"
+
+    docker login -u "$USERNAME" -p "$PASSWORD" "$CORRAL_registry_fqdn"
+else
+    corral_log "No login needed to load images"
+fi
+
+corral_log "Loading images to registry. Estimated time 1hr"
+
+bash rancher-load-images.sh --image-list rancher-images.txt --registry "$CORRAL_registry_fqdn"
+
+corral_log "Registry Host: $CORRAL_registry_fqdn"

--- a/templates/rke2/overlay/opt/corral/rke2/init-agent.sh
+++ b/templates/rke2/overlay/opt/corral/rke2/init-agent.sh
@@ -1,20 +1,25 @@
 #!/bin/bash
 
+config="server: https://${CORRAL_api_host}:9345
+token: ${CORRAL_node_token}
+"
+
+if [ "${CORRAL_registry_fqdn}" ]; then
+  config+="system-default-registry: ${CORRAL_registry_fqdn}"
+fi
+
 mkdir -p /etc/rancher/rke2
 cat > /etc/rancher/rke2/config.yaml <<- EOF
-write-kubeconfig-mode: 644
-server: https://${CORRAL_kube_api_host}:9345
-cni: ${CORRAL_cni}
-token: ${CORRAL_node_token}
-tls-san:
-  - ${CORRAL_api_host}
+${config}
 EOF
 
-curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=${CORRAL_kubernetes_version} INSTALL_RKE2_TYPE="agent" sh -
+FULL_COMMAND="${CORRAL_rke2_install_command} INSTALL_RKE2_TYPE=\"agent\" sh ${CORRAL_sh_args}"
+
+eval ${FULL_COMMAND}
 systemctl enable rke2-agent.service --now
 RET=1
 until [ ${RET} -eq 0 ]; do
-    systemctl start rke2-agent.service
-    RET=$?
-    sleep 10
+        systemctl start rke2-agent.service
+        RET=$?
+        sleep 10
 done

--- a/templates/rke2/overlay/opt/corral/rke2/init-server.sh
+++ b/templates/rke2/overlay/opt/corral/rke2/init-server.sh
@@ -1,20 +1,31 @@
 #!/bin/bash
 
-mkdir -p /etc/rancher/rke2
-cat > /etc/rancher/rke2/config.yaml <<- EOF
-write-kubeconfig-mode: 644
-server: https://${CORRAL_kube_api_host}:9345
+config="write-kubeconfig-mode: 644
 cni: ${CORRAL_cni}
+server: https://${CORRAL_api_host}:9345
 token: ${CORRAL_node_token}
 tls-san:
   - ${CORRAL_api_host}
+"
+
+if [ "${CORRAL_registry_fqdn}" ]; then
+  config+="system-default-registry: ${CORRAL_registry_fqdn}"
+fi
+
+mkdir -p /etc/rancher/rke2
+cat > /etc/rancher/rke2/config.yaml <<- EOF
+${config}
 EOF
 
-curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=${CORRAL_kubernetes_version} sh -
+FULL_COMMAND="${CORRAL_rke2_install_command} sh ${CORRAL_sh_args}"
+
+echo ${FULL_COMMAND}
+
+eval ${FULL_COMMAND}
 systemctl enable rke2-server.service
 RET=1
 until [ ${RET} -eq 0 ]; do
-    systemctl start rke2-server.service
-    RET=$?
-    sleep 10
+	systemctl start rke2-server.service
+	RET=$?
+	sleep 10
 done


### PR DESCRIPTION
Package to create Docker private registries for use in Rancher.

- This package creates a docker registry with auth or without auth using valid certificates.
- The Rancher package was updated to use `CATTLE_SYSTEM_DEFAULT_REGISTRY` during helm install if a `registry_fqdn` variable exists in corral.