### PR TITLE
Adding an optional variable that if set use an existing registry for Rancher

### DIFF
--- a/templates/rancher/manifest.yaml
+++ b/templates/rancher/manifest.yaml
@@ -19,6 +19,10 @@ variables:
   cert_manager_version:
     type: string
     description: "The cert-manager version for HA rancher install"
+  registry_fqdn:
+    type: string
+    optional: true
+    description: "The registry fqdn"
 commands:
   - command: /opt/corral/rancher/preflight.sh
     node_pools:


### PR DESCRIPTION
`registry_fqdn` is a variable used in the Rancher package install logic. If this is set that means Rancher would be installed with `systemDefaultRegistry` set to the `registry_fqdn` value.

This means this will enable use the `rancher` package without `registry-standalone` to create a new registry.

Test done. 

- Installed the `rancher` package with and without `registry_fqdn`
- E2E test of `rancher-registry`package.