### PR TITLE
add support for ubuntu, docker install, and 1.25+

### DIFF
--- a/templates/aws/registry_nodes/manifest.yaml
+++ b/templates/aws/registry_nodes/manifest.yaml
@@ -44,6 +44,10 @@ variables:
     type: boolean
     description: "Boolean that when set to true, will set the registry_fqdn to the private IP address, rather than the public IP address."
     default: false
+  install_docker:
+    description: Flag to install docker on the nodes
+    default: false
+    type: string
   instance_type:
     type: string
     optional: false

--- a/templates/aws/registry_nodes/terraform/pools/cloud-init/install-docker.yaml
+++ b/templates/aws/registry_nodes/terraform/pools/cloud-init/install-docker.yaml
@@ -1,0 +1,8 @@
+#cloud-config
+packages:
+  - docker.io
+groups:
+  - docker
+system_info:
+  default_user:
+    groups: [docker]

--- a/templates/aws/registry_nodes/terraform/pools/corral.tf
+++ b/templates/aws/registry_nodes/terraform/pools/corral.tf
@@ -12,5 +12,6 @@ variable "aws_ssh_user" {}
 variable "aws_security_group" {}
 variable "aws_vpc" {}
 variable "aws_subnet" {}
+variable "install_docker" {}
 variable "instance_type" {}
 variable "airgap_setup" {}

--- a/templates/aws/registry_nodes/terraform/pools/main.tf
+++ b/templates/aws/registry_nodes/terraform/pools/main.tf
@@ -29,7 +29,8 @@ data "cloudinit_config" "docker_service_config" {
   base64_encode = true
   part {
     content_type = "text/cloud-config"
-    content = file("${path.module}/cloud-init/setup-docker-service.yaml")
+    content = var.install_docker ? format("%s%s", file("${path.module}/cloud-init/install-docker.yaml"), file("${path.module}/cloud-init/setup-docker-service.yaml")) : file("${path.module}/cloud-init/setup-docker-service.yaml")
+
   }
 }
 

--- a/templates/rancher-airgap/overlay/opt/corral/rancher/install-rancher.sh
+++ b/templates/rancher-airgap/overlay/opt/corral/rancher/install-rancher.sh
@@ -6,16 +6,32 @@ helm repo update
 
 CORRAL_internal_rancher_host=${CORRAL_internal_rancher_host:="${CORRAL_internal_fqdn}"}
 CORRAL_rancher_version=${CORRAL_rancher_version:=$(helm search repo rancher-latest/rancher -o json | jq -r .[0].version)}
+kubernetes_version=$(kubectl version --short | awk '/Server Version:/ {print $3}')
+minor_version=$(echo "$kubernetes_version" | cut -d. -f2)
 
-helm upgrade \
---install \
---create-namespace \
---set hostname="$CORRAL_internal_rancher_host" \
---set rancherImage="$CORRAL_registry_fqdn/rancher/rancher" \
---set systemDefaultRegistry="$CORRAL_registry_fqdn" \
---version "${CORRAL_rancher_version}" \
---devel \
---wait \
-  -n cattle-system rancher rancher-latest/rancher
-  
+if [ "$minor_version" -gt 24 ]; then
+  helm upgrade \
+  --install \
+  --create-namespace \
+  --set hostname="$CORRAL_internal_rancher_host" \
+  --set rancherImage="$CORRAL_registry_fqdn/rancher/rancher" \
+  --set systemDefaultRegistry="$CORRAL_registry_fqdn" \
+  --set global.cattle.psp.enabled=false \
+  --version "${CORRAL_rancher_version}" \
+  --devel \
+  --wait \
+    -n cattle-system rancher rancher-latest/rancher
+else
+  helm upgrade \
+  --install \
+  --create-namespace \
+  --set hostname="$CORRAL_internal_rancher_host" \
+  --set rancherImage="$CORRAL_registry_fqdn/rancher/rancher" \
+  --set systemDefaultRegistry="$CORRAL_registry_fqdn" \
+  --version "${CORRAL_rancher_version}" \
+  --devel \
+  --wait \
+    -n cattle-system rancher rancher-latest/rancher
+fi
+
 echo "corral_set rancher_version=$CORRAL_rancher_version"


### PR DESCRIPTION
* rancher install on 1.25+ requires`global.cattle.psp.enabled` == false. Added a check in the shell script to add this option if user is on 1.25+

* currently, base VM (in this case, the ami in aws-ec2) is expected to already have docker installed. Adding option to allow docker install via cloud config

* corral_ssh_key_type allows non-rsa key, ed25519 to be used (see [this supporting corral PR](https://github.com/rancherlabs/corral/pull/104))

local testing:
* passing test using ami with docker pre-installed
* passing test using ami without docker pre-installed