### PR TITLE
Add support for windows in airgap

### DIFF
--- a/templates/aws/cluster_nodes/terraform/pools/corral.tf
+++ b/templates/aws/cluster_nodes/terraform/pools/corral.tf
@@ -2,6 +2,9 @@ variable "corral_name" {} // name of the corral being created
 variable "corral_user_id" {} // how the user is identified (usually github username)
 variable "corral_public_key" {} // The corrals public key.  This should be installed on every node.
 variable "corral_private_key" {} // The corrals private key.  This should be installed on every node to be able to have root access, as aws does not allow this by default.
+variable "corral_ssh_key_type" {
+    default = "rsa"
+} // The corrals ssh key type (rsa, ed25519, etc.)
 
 variable "aws_access_key" {}
 variable "aws_secret_key" {}

--- a/templates/aws/cluster_nodes/terraform/pools/main.tf
+++ b/templates/aws/cluster_nodes/terraform/pools/main.tf
@@ -49,9 +49,10 @@ resource "aws_instance" "server" {
   provisioner "remote-exec" {
     inline = var.airgap_setup ? [
       "sudo su <<EOF",
-      "echo ${var.corral_public_key} ${self.key_name} > /root/.ssh/authorized_keys",
-      "echo \"${var.corral_private_key}\" > /root/.ssh/id_rsa",
-      "chmod 700 /root/.ssh/id_rsa",
+      "echo \"${var.corral_public_key} ${self.key_name}\" > /root/.ssh/authorized_keys",
+      "echo \"${var.corral_private_key}\"",
+      "echo \"${var.corral_private_key}\" > /root/.ssh/id_${var.corral_ssh_key_type}",
+      "chmod 700 /root/.ssh/id_${var.corral_ssh_key_type}",
       "EOF",
     ]: [
       "sudo su <<EOF",
@@ -94,9 +95,10 @@ resource "aws_instance" "agent" {
   provisioner "remote-exec" {
     inline = var.airgap_setup ? [
       "sudo su <<EOF",
-      "echo ${var.corral_public_key} ${self.key_name} > /root/.ssh/authorized_keys",
-      "echo \"${var.corral_private_key}\" > /root/.ssh/id_rsa",
-      "chmod 700 /root/.ssh/id_rsa",
+      "echo \"${var.corral_public_key} ${self.key_name}\" > /root/.ssh/authorized_keys",
+      "echo \"${var.corral_private_key}\"",
+      "echo \"${var.corral_private_key}\" > /root/.ssh/id_${var.corral_ssh_key_type}",
+      "chmod 700 /root/.ssh/id_${var.corral_ssh_key_type}",
       "EOF",
     ]: [
       "sudo su <<EOF",

--- a/templates/aws/registry_nodes/manifest.yaml
+++ b/templates/aws/registry_nodes/manifest.yaml
@@ -44,6 +44,10 @@ variables:
     type: boolean
     description: "Boolean that when set to true, will set the registry_fqdn to the private IP address, rather than the public IP address."
     default: false
+  install_docker:
+    description: Flag to install docker on the nodes
+    default: false
+    type: string
   instance_type:
     type: string
     optional: false

--- a/templates/aws/registry_nodes/terraform/pools/cloud-init/install-docker.yaml
+++ b/templates/aws/registry_nodes/terraform/pools/cloud-init/install-docker.yaml
@@ -1,0 +1,8 @@
+#cloud-config
+packages:
+  - docker.io
+groups:
+  - docker
+system_info:
+  default_user:
+    groups: [docker]

--- a/templates/aws/registry_nodes/terraform/pools/corral.tf
+++ b/templates/aws/registry_nodes/terraform/pools/corral.tf
@@ -2,7 +2,9 @@ variable "corral_name" {} // name of the corral being created
 variable "corral_user_id" {} // how the user is identified (usually github username)
 variable "corral_public_key" {} // The corrals public key.  This should be installed on every node.
 variable "corral_private_key" {} // The corrals private key.  This should be installed on every node to be able to have root access, as aws does not allow this by default.
-
+variable "corral_ssh_key_type" {
+    default = "rsa"
+} // The corrals ssh key type (rsa, ed25519, etc.)
 variable "aws_access_key" {}
 variable "aws_secret_key" {}
 variable "aws_region" {}
@@ -12,5 +14,6 @@ variable "aws_ssh_user" {}
 variable "aws_security_group" {}
 variable "aws_vpc" {}
 variable "aws_subnet" {}
+variable "install_docker" {}
 variable "instance_type" {}
 variable "airgap_setup" {}

--- a/templates/aws/registry_nodes/terraform/pools/main.tf
+++ b/templates/aws/registry_nodes/terraform/pools/main.tf
@@ -29,7 +29,8 @@ data "cloudinit_config" "docker_service_config" {
   base64_encode = true
   part {
     content_type = "text/cloud-config"
-    content = file("${path.module}/cloud-init/setup-docker-service.yaml")
+    content = var.install_docker ? format("%s%s", file("${path.module}/cloud-init/install-docker.yaml"), file("${path.module}/cloud-init/setup-docker-service.yaml")) : file("${path.module}/cloud-init/setup-docker-service.yaml")
+
   }
 }
 
@@ -52,9 +53,10 @@ resource "aws_instance" "registry" {
   provisioner "remote-exec" {
     inline = var.airgap_setup ? [
       "sudo su <<EOF",
-      "echo ${var.corral_public_key} ${self.key_name} > /root/.ssh/authorized_keys",
-      "echo \"${var.corral_private_key}\" > /root/.ssh/id_rsa",
-      "chmod 700 /root/.ssh/id_rsa",
+      "echo \"${var.corral_public_key} ${self.key_name}\" > /root/.ssh/authorized_keys",
+      "echo \"${var.corral_private_key}\"",
+      "echo \"${var.corral_private_key}\" > /root/.ssh/id_${var.corral_ssh_key_type}",
+      "chmod 700 /root/.ssh/id_${var.corral_ssh_key_type}",
       "EOF",
     ]: [
       "sudo su <<EOF",

--- a/templates/rancher-airgap/overlay/opt/corral/rancher/install-rancher.sh
+++ b/templates/rancher-airgap/overlay/opt/corral/rancher/install-rancher.sh
@@ -6,16 +6,32 @@ helm repo update
 
 CORRAL_internal_rancher_host=${CORRAL_internal_rancher_host:="${CORRAL_internal_fqdn}"}
 CORRAL_rancher_version=${CORRAL_rancher_version:=$(helm search repo rancher-latest/rancher -o json | jq -r .[0].version)}
+kubernetes_version=$(kubectl version --short | awk '/Server Version:/ {print $3}')
+minor_version=$(echo "$kubernetes_version" | cut -d. -f2)
 
-helm upgrade \
---install \
---create-namespace \
---set hostname="$CORRAL_internal_rancher_host" \
---set rancherImage="$CORRAL_registry_fqdn/rancher/rancher" \
---set systemDefaultRegistry="$CORRAL_registry_fqdn" \
---version "${CORRAL_rancher_version}" \
---devel \
---wait \
-  -n cattle-system rancher rancher-latest/rancher
+if [ "$minor_version" -gt 24 ]; then
+  helm upgrade \
+  --install \
+  --create-namespace \
+  --set hostname="$CORRAL_internal_rancher_host" \
+  --set rancherImage="$CORRAL_registry_fqdn/rancher/rancher" \
+  --set systemDefaultRegistry="$CORRAL_registry_fqdn" \
+  --set global.cattle.psp.enabled=false \
+  --version "${CORRAL_rancher_version}" \
+  --devel \
+  --wait \
+    -n cattle-system rancher rancher-latest/rancher
+else
+  helm upgrade \
+  --install \
+  --create-namespace \
+  --set hostname="$CORRAL_internal_rancher_host" \
+  --set rancherImage="$CORRAL_registry_fqdn/rancher/rancher" \
+  --set systemDefaultRegistry="$CORRAL_registry_fqdn" \
+  --version "${CORRAL_rancher_version}" \
+  --devel \
+  --wait \
+    -n cattle-system rancher rancher-latest/rancher
+fi
   
 echo "corral_set rancher_version=$CORRAL_rancher_version"

--- a/templates/registry-standalone/manifest.yaml
+++ b/templates/registry-standalone/manifest.yaml
@@ -40,6 +40,9 @@ variables:
   docker_compose_version:
     type: string
     description: "The docker compose version used for running the registry"
+  windows_registry:
+    type: string
+    description: "Flag to add windows images to the registry"
 commands:
   - command: /opt/corral/registry/registry-install.sh
     node_pools:


### PR DESCRIPTION
adding new variable `windows_registry`, which will add all platforms in each manifest from `rancher-images` and `rancher-windows-images` files. 

Tested with `windows_registry=enabled` and `windows_registry=` (not set). 

note: this PR contains dependencies from https://github.com/rancherlabs/corral-packages/pull/11