### PR TITLE
Rancher image tag is no longer required.

### DIFF
--- a/templates/aws/cluster_nodes/manifest.yaml
+++ b/templates/aws/cluster_nodes/manifest.yaml
@@ -75,7 +75,7 @@ variables:
     description: "How many server nodes should be created."
   agent_count:
     type: integer
-    optional: false
+    optional: true
     description: "How many agent nodes should be created."
 commands:
   - module: pools

--- a/templates/rancher/manifest.yaml
+++ b/templates/rancher/manifest.yaml
@@ -6,6 +6,7 @@ variables:
     description: "Specify rancher version to install. Defaults to latest stable version."
   rancher_image_tag:
     type: string
+    optional: true
     description: "Specify rancher image tag for the latest commit/version of rancher."
   bootstrap_password:
     readOnly: true


### PR DESCRIPTION
accidentally enforcing rancher image tag that should not always be required.