### PR TITLE
Add RKE Setup Default to Cluster Nodes Manifest

### DIFF
--- a/templates/aws/cluster_nodes/manifest.yaml
+++ b/templates/aws/cluster_nodes/manifest.yaml
@@ -57,6 +57,10 @@ variables:
     type: boolean
     description: "Boolean that when set, will create airgap nodes rather regular cluster nodes."
     default: false
+  rke_setup:
+    type: boolean
+    description: "Boolean that when set, will create rke setup rather regular cluster nodes."
+    default: false
   instance_type:
     type: string
     optional: false


### PR DESCRIPTION
Fixes requiring extra variable by adding default `rke_setup` variable to `false`. 