### PR TITLE
Fix rancher install

### DIFF
--- a/templates/rancher/overlay/opt/corral/rancher/install-rancher.sh
+++ b/templates/rancher/overlay/opt/corral/rancher/install-rancher.sh
@@ -33,7 +33,7 @@ if [ ! -z "${CORRAL_lets_encrypt_email}" ]; then
 fi
 
 args+=("--devel" "--wait" "-n cattle-system" "rancher rancher-${CORRAL_rancher_chart_repo}/rancher")
-helm upgrade "${args[@]}"
+eval "helm upgrade ${args[*]}"
 
 echo "corral_set rancher_host=$CORRAL_rancher_host"
 echo "corral_set rancher_url=https://$CORRAL_rancher_host"

--- a/templates/rancher/overlay/opt/corral/rancher/install-rancher.sh
+++ b/templates/rancher/overlay/opt/corral/rancher/install-rancher.sh
@@ -2,7 +2,7 @@
 set -ex
 
 repos=("latest" "alpha" "stable")
-if [[ ! ${repos[@]} =~ ${CORRAL_rancher_chart_repo} ]]; then
+if [[ ! ${repos[*]} =~ ${CORRAL_rancher_chart_repo} ]]; then
   echo 'Error: `rancher_chart_repo` must be one of ["latest", "alpha", "stable"]'
   exit 1
 fi


### PR DESCRIPTION
- Reintroduce `eval` to `install_rancher.sh` in order to fix bash array expansion
- Use `[*]` for array expansions as these are more appropriate