### PR TITLE
Add a New Input for the Rancher Charts URL and Remove Read Only from Rancher Chart Repo 

### DIFF
--- a/templates/rancher/manifest.yaml
+++ b/templates/rancher/manifest.yaml
@@ -25,10 +25,13 @@ variables:
     type: string
     description: "Host of newly created rancher instance."
   rancher_chart_repo:
-    readOnly: true
     type: string
     default: "latest"
     description: "Name of Helm chart to use for Rancher install. Example: latest"
+  rancher_chart_url:
+    type: string
+    default: "https://releases.rancher.com/server-charts"
+    description: "URL of Helm chart to use for Rancher install. Example: https://releases.rancher.com/server-charts"
   cert_manager_version:
     type: string
     description: "The cert-manager version for HA rancher install"

--- a/templates/rancher/overlay/opt/corral/rancher/install-rancher.sh
+++ b/templates/rancher/overlay/opt/corral/rancher/install-rancher.sh
@@ -7,7 +7,7 @@ if [[ ! ${repos[*]} =~ ${CORRAL_rancher_chart_repo} ]]; then
   exit 1
 fi
 
-helm repo add "rancher-${CORRAL_rancher_chart_repo}" "https://releases.rancher.com/server-charts/${CORRAL_rancher_chart_repo}"
+helm repo add "rancher-${CORRAL_rancher_chart_repo}" "${CORRAL_rancher_chart_url}/${CORRAL_rancher_chart_repo}"
 helm repo update
 
 CORRAL_rancher_host=${CORRAL_rancher_host:="${CORRAL_fqdn}"}


### PR DESCRIPTION
Add support to use different helm URLs in rancher template, remove only read for rancher chart repo