### PR TITLE
updating airgap to work with staging registry.

### DIFF
--- a/packages/aws/rancher-airgap.yaml
+++ b/packages/aws/rancher-airgap.yaml
@@ -20,4 +20,4 @@ variables:
   docker_compose_version:
     - 2.15.1
   cert_manager_version:
-    - 1.8.0
+    - 1.11.0

--- a/packages/aws/rancher-registry.yaml
+++ b/packages/aws/rancher-registry.yaml
@@ -14,8 +14,8 @@ variables:
   cni:
     - calico
   kubernetes_version:
-    - v1.23.10+rke2r1
-    - v1.24.4+rke2r1
+    - v1.25.16+rke2r1
+    - v1.26.14+rke2r1
   registry_auth:
     - global
     - enabled
@@ -23,8 +23,7 @@ variables:
   docker_compose_version:
     - 2.15.1
   rancher_version:
-    - 2.7.0
-    - 2.7.1
-    - 2.7.2
+    - 2.7.10
+    - 2.8.2
   cert_manager_version:
-    - 1.8.0
+    - 1.11.0

--- a/packages/aws/registry.yaml
+++ b/packages/aws/registry.yaml
@@ -16,7 +16,7 @@ variables:
   docker_compose_version:
     - 2.15.1
   rancher_version:
-    - 2.7.0
+    - 2.8.2
   cert_manager_version:
-    - 1.8.0
+    - 1.11.0
   

--- a/packages/aws/rke2.yaml
+++ b/packages/aws/rke2.yaml
@@ -11,4 +11,4 @@ variables:
   cni:
     - calico
   kubernetes_version:
-    - v1.23.6+rke2r1
+    - v1.26.14+rke2r1

--- a/templates/rancher-airgap/manifest.yaml
+++ b/templates/rancher-airgap/manifest.yaml
@@ -19,6 +19,10 @@ variables:
   cert_manager_version:
     type: string
     description: "The cert-manager version for HA rancher install"
+  rancher_chart_url:
+    type: string
+    description: "the URL of the helm repo where rancher chart exists. i.e. https://releases.rancher.com/server-charts/latest"
+    optional: true
 commands:
   - command: /opt/corral/rancher/preflight.sh
     node_pools:

--- a/templates/rancher-airgap/overlay/opt/corral/rancher/install-cert-manager.sh
+++ b/templates/rancher-airgap/overlay/opt/corral/rancher/install-cert-manager.sh
@@ -1,21 +1,26 @@
 #!/bin/bash
 set -ex
 
-helm repo add jetstack https://charts.jetstack.io
-helm repo update
-helm fetch jetstack/cert-manager --version "v${CORRAL_cert_manager_version}"
-tar xvzf "cert-manager-v${CORRAL_cert_manager_version}.tgz"
-curl -L -o cert-manager/cert-manager-crd.yaml "https://github.com/cert-manager/cert-manager/releases/download/v${CORRAL_cert_manager_version}/cert-manager.crds.yaml"
-kubectl create namespace cert-manager
-kubectl apply -f cert-manager/cert-manager-crd.yaml
+if [ -z CORRAL_registry_cert ]; then
+    helm repo add jetstack https://charts.jetstack.io
+    helm repo update
+    helm fetch jetstack/cert-manager --version "v${CORRAL_cert_manager_version}"
+    tar xvzf "cert-manager-v${CORRAL_cert_manager_version}.tgz"
+    curl -L -o cert-manager/cert-manager-crd.yaml "https://github.com/cert-manager/cert-manager/releases/download/v${CORRAL_cert_manager_version}/cert-manager.crds.yaml"
+    kubectl create namespace cert-manager
+    kubectl apply -f cert-manager/cert-manager-crd.yaml
 
-helm install cert-manager "./cert-manager-v${CORRAL_cert_manager_version}.tgz" \
-    --namespace cert-manager \
-    --set image.repository="${CORRAL_registry_fqdn}/quay.io/jetstack/cert-manager-controller" \
-    --set webhook.image.repository="${CORRAL_registry_fqdn}/quay.io/jetstack/cert-manager-webhook" \
-    --set cainjector.image.repository="${CORRAL_registry_fqdn}/quay.io/jetstack/cert-manager-cainjector" \
-    --set startupapicheck.image.repository="${CORRAL_registry_fqdn}/quay.io/jetstack/cert-manager-ctl"
+    helm install cert-manager "./cert-manager-v${CORRAL_cert_manager_version}.tgz" \
+        --namespace cert-manager \
+        --set image.repository="${CORRAL_registry_fqdn}/quay.io/jetstack/cert-manager-controller" \
+        --set webhook.image.repository="${CORRAL_registry_fqdn}/quay.io/jetstack/cert-manager-webhook" \
+        --set cainjector.image.repository="${CORRAL_registry_fqdn}/quay.io/jetstack/cert-manager-cainjector" \
+        --set startupapicheck.image.repository="${CORRAL_registry_fqdn}/quay.io/jetstack/cert-manager-ctl"
 
-# when attempting to install rancher right after the cert-manager install there is some intermitten issues
-# allowing it to sleep for at least a 1m fixes the issue.
-sleep 1m
+    # when attempting to install rancher right after the cert-manager install there is some intermitten issues
+    # allowing it to sleep for at least a 1m fixes the issue.
+    sleep 1m
+else
+    kubectl create namespace cattle-system
+    kubectl create secret -n cattle-system tls tls-rancher-ingress --cert=/opt/basic-registry/nginx_config/domain.crt --key=/opt/basic-registry/nginx_config/domain.key
+fi

--- a/templates/registry-standalone/manifest.yaml
+++ b/templates/registry-standalone/manifest.yaml
@@ -63,6 +63,14 @@ variables:
   windows_registry:
     type: string
     description: "Flag to add windows images to the registry"
+  download_url:
+    type: string
+    description: "The download URL for all rancher registry resources. i.e. rancher-images.txt"
+    optional: true
+  suse_registry:
+    type: string
+    description: "the suse registry name, if any"
+    optional: true
 commands:
   - command: /opt/corral/registry/registry-install.sh
     node_pools:


### PR DESCRIPTION
Updating the airgap corral to work with (prime) staging registries. Adding the following variables to registry install options:
* download_url: the url where rancher install information can be downloaded from. If empty, defaults to rancher's github repo --optional
* suse_registry: the fqdn of a suse registry we are pulling the images from (i.e. docker.io , or your own fqdn registry name) -- optional

airgap install options: 
* helm_repo_url: the URL for a helm repo that should contain the rancher chart. -- optional


I made all new variables optional to ensure legacy support, and have `-z` if conditions for legacy support as well (if the options aren't specified, we use a fallback parameter.)

Other updates:
updated cert-manager to 1.11.o, the recommended version on all rancher supported versions

updated rancher to use the wildcard cert used by the registry since we use .qa.rancher.space for the registry name. This allows the rancher setup to use valid certs for tls instead of insecure cert-manger ones. 