### PR TITLE
update docker compose to a supported version

### DIFF
--- a/packages/aws/rancher-airgap.yaml
+++ b/packages/aws/rancher-airgap.yaml
@@ -18,6 +18,6 @@ variables:
   airgap_setup:
     - true
   docker_compose_version:
-    - 2.15.1
+    - 2.18.1
   cert_manager_version:
     - 1.11.0

--- a/packages/aws/rancher-registry.yaml
+++ b/packages/aws/rancher-registry.yaml
@@ -21,7 +21,7 @@ variables:
     - enabled
     - disabled
   docker_compose_version:
-    - 2.15.1
+    - 2.18.1
   rancher_version:
     - 2.7.10
     - 2.8.2

--- a/packages/aws/registry.yaml
+++ b/packages/aws/registry.yaml
@@ -14,7 +14,7 @@ variables:
     - disabled
     - ecr
   docker_compose_version:
-    - 2.15.1
+    - 2.18.1
   rancher_version:
     - 2.8.2
   cert_manager_version:


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/45424 -> our automation revealed the update of rancher images to OCI compliance breaks registries using docker 20 or below, which is EOL anyways. Updating automation to the earliest supported version of docker-compose that uses a version of docker that is in suse support matrix, docker engine 23.0.5