### PR TITLE
Corral-packages maintenance for registries

### DIFF
--- a/packages/aws/rancher-registry.yaml
+++ b/packages/aws/rancher-registry.yaml
@@ -13,17 +13,11 @@ templates:
 variables:
   cni:
     - calico
-  kubernetes_version:
-    - v1.25.16+rke2r1
-    - v1.26.14+rke2r1
   registry_auth:
     - global
     - enabled
     - disabled
   docker_compose_version:
     - 2.18.1
-  rancher_version:
-    - 2.7.10
-    - 2.8.2
   cert_manager_version:
-    - 1.11.0
+    - 1.15.0

--- a/packages/aws/registry.yaml
+++ b/packages/aws/registry.yaml
@@ -15,8 +15,5 @@ variables:
     - ecr
   docker_compose_version:
     - 2.18.1
-  rancher_version:
-    - 2.8.2
   cert_manager_version:
-    - 1.11.0
-  
+    - 1.15.0

--- a/templates/aws/registry_nodes/terraform/pools/corral.tf
+++ b/templates/aws/registry_nodes/terraform/pools/corral.tf
@@ -14,6 +14,7 @@ variable "aws_ssh_user" {}
 variable "aws_security_group" {}
 variable "aws_vpc" {}
 variable "aws_subnet" {}
+variable "aws_volume_size" {}
 variable "install_docker" {}
 variable "instance_type" {}
 variable "airgap_setup" {}

--- a/templates/aws/registry_nodes/terraform/pools/main.tf
+++ b/templates/aws/registry_nodes/terraform/pools/main.tf
@@ -44,7 +44,7 @@ resource "aws_instance" "registry" {
 
   ebs_block_device {
     device_name           = "/dev/sda1"
-    volume_size           = "200"
+    volume_size           = "${var.aws_volume_size}"
     volume_type           = "gp3"
     encrypted             = true
     delete_on_termination = true


### PR DESCRIPTION
- disable locked package variables for frequently modified variables
- allow `aws_volume_size` to be configurable for registry_nodes
- bump cert_manager version