### PR TITLE
Corral-packages maintenance for registries + rancher (rke1/rke2/k3s)

### DIFF
--- a/packages/aws/rancher-airgap.yaml
+++ b/packages/aws/rancher-airgap.yaml
@@ -20,4 +20,4 @@ variables:
   docker_compose_version:
     - 2.18.1
   cert_manager_version:
-    - 1.11.0
+    - 1.15.0

--- a/packages/aws/rancher-k3s.yaml
+++ b/packages/aws/rancher-k3s.yaml
@@ -9,14 +9,5 @@ templates:
   - k3s
   - rancher
 variables:
-  kubernetes_version:
-    - v1.26.8+k3s1
-    - v1.25.13+k3s1
-    - v1.24.17+k3s1
-    - v1.23.16+k3s1
-  rancher_version:
-    - 2.7.7
-    - 2.7.6
-    - 2.7.5
   cert_manager_version:
-    - 1.8.0
+    - 1.15.0

--- a/packages/aws/rancher-registry.yaml
+++ b/packages/aws/rancher-registry.yaml
@@ -13,17 +13,11 @@ templates:
 variables:
   cni:
     - calico
-  kubernetes_version:
-    - v1.25.16+rke2r1
-    - v1.26.14+rke2r1
   registry_auth:
     - global
     - enabled
     - disabled
   docker_compose_version:
     - 2.18.1
-  rancher_version:
-    - 2.7.10
-    - 2.8.2
   cert_manager_version:
-    - 1.11.0
+    - 1.15.0

--- a/packages/aws/rancher-rke1.yaml
+++ b/packages/aws/rancher-rke1.yaml
@@ -13,15 +13,5 @@ variables:
     - true
   cni:
     - calico
-  kubernetes_version:
-    - v1.26.8-rancher1-1
-    - v1.25.13-rancher1-1
-    - v1.24.17-rancher1-1
-    - v1.23.16-rancher2-3
-  rancher_version:
-    - 2.7.8
-    - 2.7.7
-    - 2.7.6
-    - 2.7.5
   cert_manager_version:
-    - 1.8.0
+    - 1.15.0

--- a/packages/aws/rancher-rke2.yaml
+++ b/packages/aws/rancher-rke2.yaml
@@ -11,15 +11,5 @@ templates:
 variables:
   cni:
     - calico
-  kubernetes_version:
-    - v1.26.8+rke2r1
-    - v1.25.13+rke2r1
-    - v1.24.17+rke2r1
-    - v1.23.16+rke2r1
-  rancher_version:
-    - 2.7.7
-    - 2.7.6
-    - 2.7.5
-    - 2.6.12
   cert_manager_version:
-    - 1.8.0
+    - 1.15.0

--- a/packages/aws/registry.yaml
+++ b/packages/aws/registry.yaml
@@ -15,8 +15,6 @@ variables:
     - ecr
   docker_compose_version:
     - 2.18.1
-  rancher_version:
-    - 2.8.2
   cert_manager_version:
-    - 1.11.0
+    - 1.15.0
   

--- a/templates/aws/registry_nodes/terraform/pools/corral.tf
+++ b/templates/aws/registry_nodes/terraform/pools/corral.tf
@@ -14,6 +14,7 @@ variable "aws_ssh_user" {}
 variable "aws_security_group" {}
 variable "aws_vpc" {}
 variable "aws_subnet" {}
+variable "aws_volume_size" {}
 variable "install_docker" {}
 variable "instance_type" {}
 variable "airgap_setup" {}

--- a/templates/aws/registry_nodes/terraform/pools/main.tf
+++ b/templates/aws/registry_nodes/terraform/pools/main.tf
@@ -44,7 +44,7 @@ resource "aws_instance" "registry" {
 
   ebs_block_device {
     device_name           = "/dev/sda1"
-    volume_size           = "200"
+    volume_size           = "${var.aws_volume_size}"
     volume_type           = "gp3"
     encrypted             = true
     delete_on_termination = true

--- a/templates/k3s/overlay/opt/corral/k3s/init-cluster.sh
+++ b/templates/k3s/overlay/opt/corral/k3s/init-cluster.sh
@@ -7,6 +7,7 @@ config="write-kubeconfig-mode: 644
 cluster-init: true
 tls-san:
   - ${CORRAL_api_host}
+  - ${CORRAL_kube_api_host}
 "
 
 mkdir -p /etc/rancher/k3s

--- a/templates/registry-standalone/overlay/opt/corral/registry/registry-install.sh
+++ b/templates/registry-standalone/overlay/opt/corral/registry/registry-install.sh
@@ -201,11 +201,11 @@ else
 		echo "No suse registry defined; expecting rancher/rancher image to exist in registry"
 	else
 		docker pull "${CORRAL_suse_registry}/rancher/rancher:v${CORRAL_rancher_version}"
-		docker tag "${CORRAL_suse_registry}/rancher/rancher:v${CORRAL_rancher_version}" "${CORRAL_registry_fqdn}/rancher/rancher:v${CORRAL_rancher_version}"
-		docker push "${CORRAL_registry_fqdn}/rancher/rancher:v${CORRAL_rancher_version}"
+		docker tag "${CORRAL_suse_registry}/rancher/rancher:v${CORRAL_rancher_version}" "${CORRAL_registry_fqdn}/${CORRAL_suse_registry}/rancher/rancher:v${CORRAL_rancher_version}"
+		docker push "${CORRAL_registry_fqdn}/${CORRAL_suse_registry}/rancher/rancher:v${CORRAL_rancher_version}"
 		docker pull "${CORRAL_suse_registry}/rancher/rancher-agent:v${CORRAL_rancher_version}"
-		docker tag "${CORRAL_suse_registry}/rancher/rancher-agent:v${CORRAL_rancher_version}" "${CORRAL_registry_fqdn}/rancher/rancher-agent:v${CORRAL_rancher_version}"
-		docker push "${CORRAL_registry_fqdn}/rancher/rancher-agent:v${CORRAL_rancher_version}"
+		docker tag "${CORRAL_suse_registry}/rancher/rancher-agent:v${CORRAL_rancher_version}" "${CORRAL_registry_fqdn}/${CORRAL_suse_registry}/rancher/rancher-agent:v${CORRAL_rancher_version}"
+		docker push "${CORRAL_registry_fqdn}/${CORRAL_suse_registry}/rancher/rancher-agent:v${CORRAL_rancher_version}"
 	fi
 fi
 

--- a/templates/rke2/overlay/opt/corral/rke2/init-cluster.sh
+++ b/templates/rke2/overlay/opt/corral/rke2/init-cluster.sh
@@ -7,6 +7,7 @@ config="write-kubeconfig-mode: 644
 cni: ${CORRAL_cni}
 tls-san:
   - ${CORRAL_api_host}
+  - ${CORRAL_kube_api_host}
 "
 
 if [ "${CORRAL_registry_fqdn}" ]; then


### PR DESCRIPTION
In order to properly test out these changes e2e, I've combined the work from https://github.com/rancherlabs/corral-packages/pull/53 + https://github.com/rancherlabs/corral-packages/pull/54, into a single branch, as both changes are needed to test e2e