### PR TITLE
Enhance airgap `install-rancher.sh` to support staging registry for release testing

### DIFF
--- a/templates/rancher-airgap/overlay/opt/corral/rancher/install-rancher.sh
+++ b/templates/rancher-airgap/overlay/opt/corral/rancher/install-rancher.sh
@@ -17,9 +17,10 @@ if [ -z $CORRAL_registry_cert ]; then
   --install \
   --create-namespace \
   --set hostname="$CORRAL_internal_rancher_host" \
-  --set rancherImage="$CORRAL_registry_fqdn/rancher/rancher" \
+  --set rancherImage="${CORRAL_registry_fqdn}/${CORRAL_rancher_image}" \
   --set systemDefaultRegistry="$CORRAL_registry_fqdn" \
   --set useBundledSystemChart=true \
+  --set "extraEnv[0].name=CATTLE_AGENT_IMAGE" --set "extraEnv[0].value=${CORRAL_rancher_image}-agent:v${CORRAL_rancher_version}" \
   --version "${CORRAL_rancher_version}" \
   --devel \
   --wait \
@@ -29,10 +30,11 @@ else
   --install \
   --create-namespace \
   --set hostname="$CORRAL_internal_rancher_host" \
-  --set rancherImage="$CORRAL_registry_fqdn/rancher/rancher" \
+  --set rancherImage="${CORRAL_registry_fqdn}/${CORRAL_rancher_image}" \
   --set systemDefaultRegistry="$CORRAL_registry_fqdn" \
   --set useBundledSystemChart=true \
   --set ingress.tls.source=secret \
+  --set "extraEnv[0].name=CATTLE_AGENT_IMAGE" --set "extraEnv[0].value=${CORRAL_rancher_image}-agent:v${CORRAL_rancher_version}" \
   --version "${CORRAL_rancher_version}" \
   --devel \
   --wait \


### PR DESCRIPTION
This adds support to create rancher envs for prime only releases, to be used in release testing