### PR TITLE
Add cert manager version 1.15.0

### DIFF
--- a/packages/aws/rancher-dynamic-k3s.yaml
+++ b/packages/aws/rancher-dynamic-k3s.yaml
@@ -11,4 +11,5 @@ templates:
   - rancher
 variables:
   cert_manager_version:
+    - 1.15.0
     - 1.8.0

--- a/packages/aws/rancher-dynamic-rke2.yaml
+++ b/packages/aws/rancher-dynamic-rke2.yaml
@@ -14,4 +14,5 @@ variables:
   cni:
     - calico
   cert_manager_version:
+    - 1.15.0
     - 1.11.0


### PR DESCRIPTION
### PR Description
This is a small PR to add cert manager 1.15.0 for RKE2 and K3s. As Hostbusters QA is performing daily/weekly sanity runs, we need to not be limited to one release line. Specifically, our sanity recurring job currently only runs on 2.8 due to cert manager 1.15.0 not being available.

This PR adds support so that we are unblocked from testing on all of our supported release lines.